### PR TITLE
Vagrant+ansible deploy script files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,5 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+.vagrant

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,0 +1,80 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  config.vm.box = "ubuntu/bionic64"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+
+  config.vm.provider "virtualbox" do |v|
+      v.memory = 512
+      v.cpus = 1
+  end
+
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  # config.vm.provision "shell", inline: <<-SHELL
+  #   apt-get update
+  #   apt-get install -y apache2
+  # SHELL
+  config.vm.provision "ansible" do |ansible|
+    ansible.compatibility_mode = '2.0'
+    ansible.playbook = "playbook.yml"
+    ansible.extra_vars = { ansible_python_interpreter:"/usr/bin/python3" }
+  end
+end

--- a/vagrant/database.yml
+++ b/vagrant/database.yml
@@ -1,0 +1,16 @@
+---
+- name: Database
+  become: true
+  become_user: postgres
+  postgresql_db:
+    name: decide
+
+- name: Database user
+  become: true
+  become_user: postgres
+  postgresql_user:
+    db: decide
+    name: decide
+    password: decide
+    priv: ALL
+

--- a/vagrant/django.yml
+++ b/vagrant/django.yml
@@ -1,0 +1,21 @@
+---
+- name: Collect static
+  become: yes
+  become_user: decide
+  shell: ~/venv/bin/python manage.py collectstatic --noinput
+  args:
+    chdir: /home/decide/decide/decide
+
+- name: Database migration
+  become: yes
+  become_user: decide
+  shell: ~/venv/bin/python manage.py migrate --noinput
+  args:
+    chdir: /home/decide/decide/decide
+
+- name: Admin superuser
+  become: yes
+  become_user: decide
+  shell: ~/venv/bin/python manage.py shell -c "from django.contrib.auth.models import User; User.objects.filter(username='admin') or User.objects.create_superuser('admin', 'admin@example.com', 'admin')"
+  args:
+    chdir: /home/decide/decide/decide

--- a/vagrant/files.yml
+++ b/vagrant/files.yml
@@ -1,0 +1,21 @@
+---
+- name: decide sysmtemd service
+  become: yes
+  become_user: root
+  copy:
+    src: files/decide.service
+    dest: /etc/systemd/system/decide.service
+
+- name: nginx.conf file
+  become: yes
+  become_user: root
+  copy:
+    src: files/nginx.conf
+    dest: /etc/nginx/conf.d/default.conf
+
+- name: django local_settings.py
+  become: yes
+  become_user: decide
+  copy:
+    src: files/settings.py
+    dest: /home/decide/decide/decide/local_settings.py

--- a/vagrant/files/decide.service
+++ b/vagrant/files/decide.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=decide
+
+[Service]
+User=decide
+Type=simple
+PIDFile=/var/run/decide.pid
+WorkingDirectory=/home/decide/decide/decide
+ExecStart=/home/decide/venv/bin/gunicorn -w 5 decide.wsgi --timeout=500 -b 0.0.0.0:8000
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/vagrant/files/nginx.conf
+++ b/vagrant/files/nginx.conf
@@ -1,0 +1,24 @@
+server {
+    listen       80;
+
+    server_name  localhost;
+    root         /home/decide/;
+
+    location / {
+        include             fastcgi_params;
+        proxy_pass          http://localhost:8000;
+        proxy_redirect      off;
+
+        proxy_connect_timeout 500;
+        proxy_read_timeout 500;
+
+        proxy_set_header    Host            $host;
+        proxy_set_header    X-Real-IP       $remote_addr;
+        proxy_set_header    X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    location /static {
+        autoindex on;
+        alias /home/decide/static;
+    }
+}

--- a/vagrant/files/settings.py
+++ b/vagrant/files/settings.py
@@ -1,0 +1,43 @@
+DEBUG = True
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql',
+        'NAME': 'decide',
+        'USER': 'decide',
+        'PASSWORD': 'decide',
+        'HOST': 'localhost',
+        'PORT': 5432,
+    }
+}
+
+STATIC_ROOT = '/home/decide/static/'
+MEDIA_ROOT = '/home/decide/static/media/'
+ALLOWED_HOSTS = ['*']
+
+# Modules in use, commented modules that you won't use
+MODULES = [
+    'authentication',
+    'base',
+    'booth',
+    'census',
+    'mixnet',
+    'postproc',
+    'store',
+    'visualizer',
+    'voting',
+]
+
+BASEURL = 'http://localhost:8000'
+
+APIS = {
+    'authentication': 'http://localhost:8000',
+    'base': 'http://localhost:8000',
+    'booth': 'http://localhost:8000',
+    'census': 'http://localhost:8000',
+    'mixnet': 'http://localhost:8000',
+    'postproc': 'http://localhost:8000',
+    'store': 'http://localhost:8000',
+    'visualizer': 'http://localhost:8000',
+    'voting': 'http://localhost:8000',
+}

--- a/vagrant/packages.yml
+++ b/vagrant/packages.yml
@@ -1,0 +1,22 @@
+---
+- name: Install packages
+  become: true
+  apt:
+    name: "{{ packages }}"
+    update_cache: yes
+  vars:
+    packages:
+    - git
+    - postgresql
+    - python3
+    - python3-pip
+    - python3-psycopg2
+    - python3-virtualenv
+    - virtualenv
+    - nginx
+    - libpq-dev
+    - python-setuptools
+    - build-essential
+    - python-dev
+    - make
+    - m4

--- a/vagrant/playbook.yml
+++ b/vagrant/playbook.yml
@@ -1,0 +1,17 @@
+---
+- hosts: all
+
+  tasks:
+    - include: packages.yml
+      tags: ["packages"]
+    - include: user.yml
+    - include: python.yml
+      tags: ["app"]
+    - include: files.yml
+      tags: ["files"]
+    - include: database.yml
+      tags: ["database"]
+    - include: django.yml
+      tags: ["django"]
+    - include: services.yml
+      tags: ["services"]

--- a/vagrant/python.yml
+++ b/vagrant/python.yml
@@ -1,0 +1,24 @@
+---
+- name: Git clone
+  become: yes
+  become_user: decide
+  git:
+    repo: 'https://github.com/wadobo/decide.git'
+    dest: /home/decide/decide
+    version: master
+
+- name: Python virtualenv
+  become: yes
+  become_user: decide
+  pip:
+    name: "gunicorn"
+    virtualenv: /home/decide/venv
+    virtualenv_python: python3
+
+- name: Requirements
+  become: yes
+  become_user: decide
+  pip:
+    requirements: /home/decide/decide/requirements.txt
+    virtualenv: /home/decide/venv
+    virtualenv_python: python3

--- a/vagrant/services.yml
+++ b/vagrant/services.yml
@@ -1,0 +1,12 @@
+---
+- name: Starting services
+  become: yes
+  become_user: root
+  systemd:
+    state: restarted
+    enabled: yes
+    name: "{{ item }}"
+  loop:
+    - postgresql
+    - nginx
+    - decide

--- a/vagrant/user.yml
+++ b/vagrant/user.yml
@@ -1,0 +1,7 @@
+---
+- name: Create decide user
+  become: true
+  user:
+    name: decide
+    comment: Decide app user
+    state: present


### PR DESCRIPTION
This PR adds the a new folder with a Vagrant file and an ansible playbook to deploy decide in a virtual machine easily.

It's really easy now to deploy with vagrant doing:

```
$ cd vagrant
$ vagrant up
```

And we'll have the application running in http://localhost:8080/admin, with the user "admin:admin" created.